### PR TITLE
[Fix]: Move overlay with dark background under text on homepage at hero section

### DIFF
--- a/components/TheHotNews.vue
+++ b/components/TheHotNews.vue
@@ -39,7 +39,7 @@ export default {
 
 <style scoped lang="scss">
 .wrapper {
-  background: rgba(91,91,91,0.65);
+  background: rgba(91,91,91,0.8);
   height: 100%;
   padding: 40px 0;
 }

--- a/components/TheSlider.vue
+++ b/components/TheSlider.vue
@@ -1,10 +1,10 @@
 <template lang="pug">
 .wrapper.desctop(v-if="showCarousel")
   .inner
-    .opacity
     carousel.slider(
       :perPage="1"
     )
+      .opacity
       slide.slide(
         v-for="(slide, index) in slides",
         :key="slide.id",
@@ -103,10 +103,12 @@ export default {
 }
 
 .opacity {
-  opacity: 0.3;
+  opacity: 1;
   background: #5B5B5B;
+  background-color: rgba(0, 0, 0, 0.5);
   position: absolute;
   top: 0;
+  width: 100%;
   left: 0;
   bottom: 0;
   right: 0;
@@ -142,7 +144,6 @@ export default {
 
 .slide-article__wrapper {
   padding: 100% 40px 84px 40px;
-  background-color: rgba(0, 0, 0, 0.5);
 }
 .content {
   // max-width: 1200px;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5647725/97548618-6868cf00-19e0-11eb-9d62-164c40cdea32.png)
![image](https://user-images.githubusercontent.com/5647725/97548581-5be47680-19e0-11eb-9a55-3b0239b0c564.png)
